### PR TITLE
Support Go 1.18

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,6 @@ on: [push, pull_request]
 name: Test
 jobs:
   test:
-    if: false # We disable CI for now since no versions of Go support necessary features to test dogs.
     strategy:
       matrix:
         go-version: [1.18.x]

--- a/classes/algebra/algebra.go
+++ b/classes/algebra/algebra.go
@@ -1,6 +1,6 @@
 package algebra
 
-import "constraints"
+import "golang.org/x/exp/constraints"
 
 // Additive is a type that can use `+` operator.
 type Additive interface {

--- a/classes/cmp/cmp.go
+++ b/classes/cmp/cmp.go
@@ -1,7 +1,7 @@
 package cmp
 
 import (
-	"constraints"
+	"golang.org/x/exp/constraints"
 	"fmt"
 )
 

--- a/dogs.go
+++ b/dogs.go
@@ -2,8 +2,10 @@
 package dogs
 
 // TODO: ./dogs.go:11:16: syntax error: generic type cannot be alias
+// https://github.com/golang/go/issues/46477
 
 // type Eq[T any] = cmp.Eq[T]
+
 // type Ord[T any] = cmp.Ord[T]
 
 // type Semigroup[T any] = algebra.Semigroup[T]

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,12 @@ module github.com/genkami/dogs
 go 1.18
 
 require (
+	github.com/stretchr/testify v1.7.0
+	golang.org/x/exp v0.0.0-20220321173239-a90fa8a75705
+)
+
+require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,9 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/exp v0.0.0-20220321173239-a90fa8a75705 h1:ba9YlqfDGTTQ5aZ2fwOoQ1hf32QySyQkR6ODGDzHlnE=
+golang.org/x/exp v0.0.0-20220321173239-a90fa8a75705/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/types/iterator/iterator.go
+++ b/types/iterator/iterator.go
@@ -1,7 +1,7 @@
 package iterator
 
 import (
-	"constraints"
+	"golang.org/x/exp/constraints"
 	"github.com/genkami/dogs/classes/algebra"
 	"github.com/genkami/dogs/classes/cmp"
 	"github.com/genkami/dogs/types/pair"


### PR DESCRIPTION
Since Go 1.18 is released, we can run CI on GH Actions.