### PR TITLE
fix typo in the comment for Chan[T]

### DIFF
--- a/types/channel/channel.go
+++ b/types/channel/channel.go
@@ -4,7 +4,7 @@ import (
 	"github.com/genkami/dogs/types/iterator"
 )
 
-// Channel[T] is a channel of type T.
+// Chan[T] is a channel of type T.
 type Chan[T any] chan T
 
 //go:generate go run ../../cmd/gen-functions -template Collection -pkg channel -name Chan -out zz_generated.collection.go


### PR DESCRIPTION
The comment for `Chan[T]` starts with `Channel[T] is ...`. That does not match the type name.